### PR TITLE
Fix message handler and logging

### DIFF
--- a/TelegramBotFramework/Services/UserJoinedUpdateHandler.cs
+++ b/TelegramBotFramework/Services/UserJoinedUpdateHandler.cs
@@ -30,12 +30,11 @@ namespace TelegramBotFramework.Services
 
         public Task<bool> CanHandleUpdateAsync(ITelegramBotClient telegramBotClient, Update update, CancellationToken cancellationToken)
         {
-            if (update.Type == UpdateType.Message)
-            {
-                return update.Message?.Type == MessageType.NewChatMembers ? Task.FromResult(update.Message.NewChatMembers != null) : Task.FromResult(false);
-            }
-
-            return Task.FromResult(false);
+            // We need to handle both messages from new chat members and
+            // subsequent answers from users. Returning true for any
+            // "Message" update ensures we don't ignore messages that
+            // contain potential answers.
+            return Task.FromResult(update.Type == UpdateType.Message);
         }
     }
 }

--- a/TelegramBotFramework/TelegramPollingJob.cs
+++ b/TelegramBotFramework/TelegramPollingJob.cs
@@ -30,7 +30,7 @@ namespace TelegramBotFramework
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
-            logger.LogInformation("Job started");
+            logger.LogInformation("Job stopped");
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
## Summary
- fix `CanHandleUpdateAsync` so answer messages are processed
- fix logging on polling stop

## Testing
- `dotnet test TelegramBotFramework.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684021d0fb44832fbf3aad1c636d9dfe