### PR TITLE
Implement PendingQuestionsService

### DIFF
--- a/TelegramBotFramework/Services/PendingQuestionsService.cs
+++ b/TelegramBotFramework/Services/PendingQuestionsService.cs
@@ -1,16 +1,47 @@
 namespace TelegramBotFramework.Services
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Telegram.Bot.Types;
 
     public class PendingQuestionsService : IPendingQuestionsService
     {
-        public Task AddQuestion(User user, Question question) =>
-            throw new NotImplementedException();
+        private readonly Dictionary<long, (User User, Question Question)> _pending = new();
 
-        public Task CheckAnswer(User user, string answer) =>
-            throw new NotImplementedException();
+        public Task AddQuestion(User user, Question question)
+        {
+            lock (_pending)
+            {
+                _pending[user.Id] = (user, question);
+            }
 
-        public Task<IReadOnlyList<User>> GetPendingUsers() =>
-            throw new NotImplementedException();
+            return Task.CompletedTask;
+        }
+
+        public Task CheckAnswer(User user, string answer)
+        {
+            lock (_pending)
+            {
+                if (_pending.TryGetValue(user.Id, out var pending) &&
+                    string.Equals(pending.Question.Answer, answer, StringComparison.OrdinalIgnoreCase))
+                {
+                    _pending.Remove(user.Id);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<User>> GetPendingUsers()
+        {
+            List<User> users;
+            lock (_pending)
+            {
+                users = _pending.Values.Select(v => v.User).ToList();
+            }
+
+            return Task.FromResult((IReadOnlyList<User>)users);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement pending question tracking with a dictionary
- add logic for adding, checking, and listing pending users

## Testing
- `dotnet build TelegramBotFramework.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684024836ac0832f8579886cb626c81b