### PR TITLE
Add AUTH_TOKEN configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains a sample Telegram bot built with ASP.NET Core and the T
 
 ## Getting started
 1. Install the .NET 8 SDK.
-2. Set your bot token in the `BotToken` configuration value or as an environment variable.
+2. Set your bot token in the `AUTH_TOKEN` configuration value or as the `AUTH_TOKEN` environment variable.
 3. Run the bot:
    ```bash
    dotnet run --project TelegramBot.Web

--- a/TelegramBot.Web/Program.cs
+++ b/TelegramBot.Web/Program.cs
@@ -8,8 +8,8 @@ var builder = WebApplication.CreateBuilder(args);
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-var botToken = builder.Configuration.GetSection("BotToken").Get<string>();
-if (botToken != null)
+var botToken = builder.Configuration["AUTH_TOKEN"];
+if (!string.IsNullOrEmpty(botToken))
 {
     builder.Services.AddSingleton<ITelegramBotClient>(new TelegramBotClient(botToken));
 }

--- a/TelegramBot.Web/appsettings.Development.json
+++ b/TelegramBot.Web/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "AUTH_TOKEN": ""
 }

--- a/TelegramBot.Web/appsettings.json
+++ b/TelegramBot.Web/appsettings.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AUTH_TOKEN": ""
 }


### PR DESCRIPTION
## Summary
- store `AUTH_TOKEN` in appsettings files
- retrieve the token via `builder.Configuration["AUTH_TOKEN"]`
- document token setup in the README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684030ce6c64832fb386cd62156ad637