### PR TITLE
Implement OpenAI chat service

### DIFF
--- a/TelegramBotFramework.Tests/Services/OpenAiChatServiceTests.cs
+++ b/TelegramBotFramework.Tests/Services/OpenAiChatServiceTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using System.ClientModel.Primitives;
+using ModelContextProtocol;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using OpenAI.Chat;
+using System.ClientModel;
+using TelegramBotFramework.Services;
+using Xunit;
+
+namespace TelegramBotFramework.Tests.Services
+{
+    public class OpenAiChatServiceTests
+    {
+        private class FakePipelineResponse : PipelineResponse
+        {
+            private readonly BinaryData _content;
+            public FakePipelineResponse(string json) => _content = BinaryData.FromString(json);
+            public override int Status => 200;
+            public override string ReasonPhrase => "OK";
+            protected override PipelineResponseHeaders HeadersCore { get; } = new EmptyHeaders();
+            public override Stream? ContentStream { get; set; }
+            public override BinaryData Content => _content;
+            public override BinaryData BufferContent(CancellationToken cancellationToken = default) => _content;
+            public override ValueTask<BinaryData> BufferContentAsync(CancellationToken cancellationToken = default) => new(_content);
+            public override void Dispose() { }
+            private sealed class EmptyHeaders : PipelineResponseHeaders
+            {
+                public override IEnumerator<KeyValuePair<string, string>> GetEnumerator() => Enumerable.Empty<KeyValuePair<string, string>>().GetEnumerator();
+                public override bool TryGetValue(string name, out string? value) { value = null; return false; }
+                public override bool TryGetValues(string name, out IEnumerable<string>? values) { values = null; return false; }
+            }
+        }
+
+        private static ClientResult<ChatCompletion> CreateResult(string text)
+        {
+            string json = $"{{\"id\":\"1\",\"choices\":[{{\"message\":{{\"role\":\"assistant\",\"content\":\"{text}\"}},\"finish_reason\":\"stop\"}}],\"created\":0,\"model\":\"gpt-4o\"}}";
+            var resp = new FakePipelineResponse(json);
+            var fromResponse = typeof(ChatCompletion).GetMethod("FromResponse", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+            var completion = (ChatCompletion)fromResponse.Invoke(null, new object[] { resp })!;
+            var fromValue = typeof(ClientResult).GetMethod("FromValue")!.MakeGenericMethod(typeof(ChatCompletion));
+            return (ClientResult<ChatCompletion>)fromValue.Invoke(null, new object[] { completion, resp })!;
+        }
+
+        private class FakeChatClient : ChatClient
+        {
+            private readonly ClientResult<ChatCompletion> _result;
+            public FakeChatClient(ClientResult<ChatCompletion> result) : base("gpt-4o", "fake") => _result = result;
+            public override Task<ClientResult<ChatCompletion>> CompleteChatAsync(IEnumerable<ChatMessage> messages, ChatCompletionOptions options = null, CancellationToken cancellationToken = default) => Task.FromResult(_result);
+        }
+
+        private class FakeMcpClient : IMcpClient
+        {
+            public ServerCapabilities ServerCapabilities { get; } = new();
+            public Implementation ServerInfo { get; } = new() { Name = "test", Version = "1.0" };
+            public string? ServerInstructions => string.Empty;
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+            public Task SendMessageAsync(JsonRpcMessage message, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            public IAsyncDisposable RegisterNotificationHandler(string method, Func<JsonRpcNotification, CancellationToken, ValueTask> handler) => new Dummy();
+            private class Dummy : IAsyncDisposable { public ValueTask DisposeAsync() => ValueTask.CompletedTask; }
+            public Task<JsonRpcResponse> SendRequestAsync(JsonRpcRequest request, CancellationToken cancellationToken = default)
+            {
+                var tool = new Tool
+                {
+                    Name = "echo",
+                    Description = "Echo",
+                    InputSchema = JsonSerializer.Deserialize<JsonElement>("{\"type\":\"object\",\"properties\":{\"message\":{\"type\":\"string\"}},\"required\":[\"message\"]}")
+                };
+                var result = new ListToolsResult { Tools = new List<Tool> { tool } };
+                var json = JsonSerializer.Serialize(result);
+                var node = JsonNode.Parse(json);
+                return Task.FromResult(new JsonRpcResponse { Id = request.Id, Result = node });
+            }
+        }
+
+        [Fact]
+        public async Task GetCompletion_ReturnsCompletionText()
+        {
+            var chatResult = CreateResult("pong");
+            var service = new OpenAiChatService(new FakeChatClient(chatResult), new FakeMcpClient());
+            var result = await service.GetCompletion("ping");
+            Assert.Equal("pong", result);
+        }
+    }
+}

--- a/TelegramBotFramework/Services/EchoTool.cs
+++ b/TelegramBotFramework/Services/EchoTool.cs
@@ -1,0 +1,12 @@
+namespace TelegramBotFramework.Services
+{
+    using System.ComponentModel;
+    using ModelContextProtocol.Server;
+
+    [McpServerToolType]
+    public static class EchoTool
+    {
+        [McpServerTool, Description("Echoes the message back to the client.")]
+        public static string Echo(string message) => message;
+    }
+}

--- a/TelegramBotFramework/Services/IOpenAiChatService.cs
+++ b/TelegramBotFramework/Services/IOpenAiChatService.cs
@@ -1,0 +1,10 @@
+namespace TelegramBotFramework.Services
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public interface IOpenAiChatService
+    {
+        Task<string> GetCompletion(string userText, CancellationToken cancellationToken = default);
+    }
+}

--- a/TelegramBotFramework/Services/OpenAiChatService.cs
+++ b/TelegramBotFramework/Services/OpenAiChatService.cs
@@ -1,0 +1,54 @@
+namespace TelegramBotFramework.Services
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using ModelContextProtocol.Client;
+    using System.ClientModel;
+    using System.ClientModel.Primitives;
+    using OpenAI.Chat;
+
+    public class OpenAiChatService : IOpenAiChatService
+    {
+        private readonly ChatClient _client;
+        private readonly IMcpClient _mcpClient;
+
+        public OpenAiChatService(string authToken, IMcpClient mcpClient)
+            : this(new ChatClient(model: "gpt-4o", apiKey: authToken), mcpClient)
+        {
+        }
+
+        public OpenAiChatService(ChatClient client, IMcpClient mcpClient)
+        {
+            _client = client;
+            _mcpClient = mcpClient;
+        }
+
+        public async Task<string> GetCompletion(string userText, CancellationToken cancellationToken = default)
+        {
+            var messages = new ChatMessage[]
+            {
+                new SystemChatMessage("You are a helpful assistant."),
+                new UserChatMessage(userText)
+            };
+
+            IList<McpClientTool> tools = await _mcpClient.ListToolsAsync(cancellationToken: cancellationToken);
+
+            ChatCompletionOptions options = new();
+            foreach (var tool in tools)
+            {
+                var schemaJson = tool.ProtocolTool.InputSchema.GetRawText();
+                ChatTool chatTool = ChatTool.CreateFunctionTool(
+                    functionName: tool.Name,
+                    functionDescription: tool.Description,
+                    functionParameters: BinaryData.FromString(schemaJson));
+                options.Tools.Add(chatTool);
+            }
+
+            ClientResult<ChatCompletion> completion = await _client.CompleteChatAsync(messages, options, cancellationToken);
+            ChatCompletion result = completion.Value;
+            return result.Content.Count > 0 ? result.Content[0].Text : string.Empty;
+        }
+    }
+}

--- a/TelegramBotFramework/TelegramBotFramework.csproj
+++ b/TelegramBotFramework/TelegramBotFramework.csproj
@@ -8,10 +8,10 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+      <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="OpenAI" Version="2.1.0" />
       <PackageReference Include="Telegram.Bot" Version="22.1.0" />
-      <PackageReference Include="MCP" Version="1.0.0" />
-      <PackageReference Include="OpenAI.Client" Version="1.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add `IOpenAiChatService` interface
- implement `OpenAiChatService` using MCP and OpenAI client
- create `OpenAiChatServiceTests` covering chat completions

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684031a5a948832faec13ea1b6ba52c4